### PR TITLE
Fix URL concatenation bug and README documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     VENDOR = "<YOUR_VENDOR_NAME>"
     CONFIG_PATH = "<PATH_TO_YOUR_YAML_FILE>"
     OUTPUT_FILE = "<PATH_TO_YOUR_JSON_FILE>"
-    data = asyncio.run(main(VENDOR, CONFIG, OUTPUT_FILE))
+    data = asyncio.run(main(VENDOR, CONFIG_PATH, OUTPUT_FILE))
 ```
 
 > Remember: **YOUR_VENDOR_NAME** should match one in the **<CONFIG_PATH>.yaml** file.

--- a/scrapeall/parse.py
+++ b/scrapeall/parse.py
@@ -1,11 +1,11 @@
 from itertools import chain
-from typing import Dict, Union, Any
-from urllib.parse import urlparse
+from typing import Any, Dict, Union
+from urllib.parse import urljoin, urlparse
 
 import requests
+from bs4 import BeautifulSoup
 from omegaconf import OmegaConf
 from pyppeteer import launch
-from bs4 import BeautifulSoup
 
 
 class HTMLParser:
@@ -59,7 +59,7 @@ class HTMLParser:
                         ._replace(path="")
                         .geturl()
                     )
-                    link = base_url + link
+                link = urljoin(base_url, link)
                 self.urls[text] = link
 
     async def get_page_content(self, config: Dict[str, Union[list, str, dict]]):


### PR DESCRIPTION
Fixes two issues:
- Use `urljoin()` instead of string concatenation to prevent malformed URLs 
- Correct variable name from `CONFIG` to `CONFIG_PATH` in README example